### PR TITLE
75: Remove pricing from navigation. Resolves #75

### DIFF
--- a/site/utils/navLinks.ts
+++ b/site/utils/navLinks.ts
@@ -35,12 +35,12 @@ export const navigationLinks: INavigationProps["links"] = [
 		// 	},
 		// ],
 	},
-	{
-		link: {
-			label: "Pricing",
-			path: "/pricing",
-		},
-	},
+	// {
+	// 	link: {
+	// 		label: "Pricing",
+	// 		path: "/pricing",
+	// 	},
+	// },
 	{
 		link: {
 			label: "Gallery",


### PR DESCRIPTION
- Temporarily hiding pricing page until information is set. Resolves #75 